### PR TITLE
fix: add explicit permissions to GitHub App token in tagpr workflow

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -20,6 +20,11 @@ jobs:
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permissions: |
+            contents: write
+            pull-requests: write
+            issues: write
+            actions: write
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:


### PR DESCRIPTION
## Summary

- Added explicit `permissions` field to `actions/create-github-app-token` action
- Fixes permission errors when tagpr tries to create labels on PRs

## Problem

The tagpr workflow was failing with:
```
POST https://api.github.com/repos/yuya-takeyama/panama/issues/11/labels: 403 
You do not have permission to create labels on this repository
```

## Root Cause

`actions/create-github-app-token` v2.0.0 introduced a breaking change where permissions must be explicitly specified. Without explicit permissions, the token only gets minimal permissions.

## Solution

Added explicit permissions to the GitHub App token generation:
```yaml
permissions: |
  contents: write
  pull-requests: write
  issues: write
  actions: write
```

## Related

- Failed CI run: https://github.com/yuya-takeyama/panama/actions/runs/17026481742/job/48262482901
- Breaking change in v2.0.0: https://github.com/actions/create-github-app-token/releases/tag/v2.0.0

---
Generated with Claude assistance