### PR TITLE
fix: use correct permission parameter format for create-github-app-token v2

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -20,11 +20,10 @@ jobs:
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: |
-            contents: write
-            pull-requests: write
-            issues: write
-            actions: write
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
+          permission-actions: write
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:


### PR DESCRIPTION
## Summary

Fixed the permission parameter format for `actions/create-github-app-token@v2.1.1` to use individual permission parameters instead of the invalid `permissions` field.

## Problem

The previous PR used an incorrect `permissions` parameter which caused the workflow to fail with:
```
Warning: Unexpected input(s) 'permissions', valid inputs are ['permission-contents', 'permission-issues', 'permission-pull-requests', ...]
```

## Solution

Changed to use individual permission parameters as required by v2.x of the action:
- `permission-contents: write`
- `permission-pull-requests: write`
- `permission-issues: write`
- `permission-actions: write`

## Testing

The CI should now pass without warnings and tagpr should be able to create labels on PRs.

## Related

- Previous PR: #12
- v2.0.0 breaking changes: https://github.com/actions/create-github-app-token/releases/tag/v2.0.0

---
Generated with Claude assistance