### PR TITLE
fix: remove explicit permission parameters from GitHub App token

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -20,10 +20,6 @@ jobs:
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permission-contents: write
-          permission-pull-requests: write
-          permission-issues: write
-          permission-actions: write
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:


### PR DESCRIPTION
## Summary

Remove all explicit permission-* parameters from the GitHub App token generation to fix the "permissions not granted" error.

## Problem

The tagpr workflow was failing with:
```
The permissions requested are not granted to this installation.
```

This happens because the GitHub App installation doesn't have all the permissions we were explicitly requesting:
- permission-contents: write
- permission-pull-requests: write
- permission-issues: write
- permission-actions: write

## Solution

Remove all explicit permission parameters and let the action use whatever permissions the GitHub App installation already has. The app should already have the necessary permissions configured at the installation level.

## Testing

The workflow should now successfully generate a GitHub App token using the app's existing permissions.

## Related

- Failed CI run: https://github.com/yuya-takeyama/panama/actions/runs/17026666879/job/48262873501
- Previous attempts: #12, #14

---
Generated with Claude assistance