### PR TITLE
feat: add missing tools to aqua.yaml

### DIFF
--- a/aqua/aqua-checksums.json
+++ b/aqua/aqua-checksums.json
@@ -21,6 +21,31 @@
       "algorithm": "sha256"
     },
     {
+      "id": "github_release/github.com/anchore/syft/v1.29.1/syft_1.29.1_darwin_amd64.tar.gz",
+      "checksum": "A8B6F82AFDAC8E0DF8F34AFFC05ACE17DA2FF4D9B9F56AC4231DD6AA50D282B2",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/anchore/syft/v1.29.1/syft_1.29.1_darwin_arm64.tar.gz",
+      "checksum": "577018D66C93780B0E92EC8CA9F11F9B9EA98A364036F5BC29DA6E51C81F1CD2",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/anchore/syft/v1.29.1/syft_1.29.1_linux_amd64.tar.gz",
+      "checksum": "CA704907E5A7B697C6E683832CA128E2AE60DE63D7D87F3E2E39672DF9038FA4",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/anchore/syft/v1.29.1/syft_1.29.1_linux_arm64.tar.gz",
+      "checksum": "D8ABA89EEF3F9A80A650B608366C7E0E284763D59C54D2AC0808DEC27BC1CBC4",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/anchore/syft/v1.29.1/syft_1.29.1_windows_amd64.zip",
+      "checksum": "3C67CD9AF40CDCC7FFCE041C8349B4A77F33810184820C05DF23440C8E0AA1D7",
+      "algorithm": "sha256"
+    },
+    {
       "id": "github_release/github.com/cli/cli/v2.76.0/gh_2.76.0_linux_amd64.tar.gz",
       "checksum": "BC46A0F43FA357CDFCFFC77F92A48303F5BACD97CF3E59A807DA2682CA4126DA",
       "algorithm": "sha256"
@@ -73,6 +98,31 @@
     {
       "id": "github_release/github.com/goreleaser/goreleaser/v2.11.1/goreleaser_Windows_x86_64.zip",
       "checksum": "7EF5EE78A55BFC24107B5E8815EF83D6784CB548FF6A558D6D05D077A2E7FF1E",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/sigstore/cosign/v2.5.3/cosign-darwin-amd64",
+      "checksum": "172731B1C2575DD76069A87D4D17312FD027FE0947E45E4A9BA9B915877E0ED0",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/sigstore/cosign/v2.5.3/cosign-darwin-arm64",
+      "checksum": "86E0CAD94D0DA4C0DAB5E26672EDE71447A08A0F0D8495B9381C117DF27D7D09",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/sigstore/cosign/v2.5.3/cosign-linux-amd64",
+      "checksum": "783B5D6C74105401C63946C68D9B2A4E1AAB3C8ABCE043E06B8510B02B623EC9",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/sigstore/cosign/v2.5.3/cosign-linux-arm64",
+      "checksum": "BFFABE4CF183122B7DE3111257A863C99E7DC6CF1093BFD7BF961DE1795589B8",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/sigstore/cosign/v2.5.3/cosign-windows-amd64.exe",
+      "checksum": "545D87E096CAB55E213F25B6EC5C9A74C958F72D05182CEE1CD53A4EB6C2E561",
       "algorithm": "sha256"
     },
     {

--- a/aqua/aqua.yaml
+++ b/aqua/aqua.yaml
@@ -15,3 +15,6 @@ packages:
   - name: goreleaser/goreleaser@v2.11.1
   - name: Songmu/tagpr@v1.7.0
   - name: suzuki-shunsuke/pinact@v3.4.1
+  - name: sigstore/cosign@v2.5.3
+  - name: google/go-licenses@v1.6.0
+  - name: anchore/syft@v1.29.1


### PR DESCRIPTION
## Summary

- Add missing tools to aqua.yaml for development environment setup
- Keep existing newer versions as specified

## Added packages

- `sigstore/cosign@v2.5.3` - Container image signing tool
- `google/go-licenses@v1.6.0` - License detection for Go packages
- `anchore/syft@v1.29.1` - SBOM generation tool

## Note

- `cli/cli@v2.76.0` and `goreleaser/goreleaser@v2.11.1` were already present
- `suzuki-shunsuke/pinact@v3.4.1` was kept as-is (newer than requested v3.3.2)

---
Generated with Claude assistance