### PR TITLE
fix: add third_party_licenses to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ go.work.sum
 # Build output (binary only at root)
 /panama
 
+# Third party licenses generated during build
+third_party_licenses/
+
 # OS
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
## Summary

- Add `third_party_licenses/` directory to `.gitignore`
- This directory is generated during build by go-licenses tool
- Fixes goreleaser dirty state error in CI

## Problem

The CI was failing because goreleaser detected an untracked directory (`third_party_licenses/`) that gets created during the build process. This caused goreleaser to exit with "git is in a dirty state" error.

## Solution

Add the `third_party_licenses/` directory to `.gitignore` since it is a build artifact that should not be committed to the repository.

## Test Plan

- [ ] CI passes successfully
- [ ] goreleaser no longer reports dirty state
- [ ] Build process completes without errors

Generated with Claude assistance