### PR TITLE
docs: rename shell function from pw to jump for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ Add to your `~/.bashrc` or `~/.zshrc`:
 
 ```bash
 # Quick workspace switcher
-pw() {
+# You can name this function whatever you like (e.g., j, pw, workspace, etc.)
+jump() {
   local dir
   dir=$(panama select "$@")
   if [[ -n "$dir" ]]; then
@@ -142,10 +143,11 @@ pw() {
 
 ### Fish
 
-Add to your `~/.config/fish/functions/pw.fish`:
+Add to your `~/.config/fish/functions/jump.fish`:
 
 ```fish
-function pw
+# You can name this function whatever you like (e.g., j, pw, workspace, etc.)
+function jump
   set -l dir (panama select $argv)
   if test -n "$dir"
     cd $dir


### PR DESCRIPTION
## Summary
- Renamed shell function from `pw` to `jump` to avoid confusion with `pwd` command
- Added comments indicating users can name the function whatever they prefer (j, pw, workspace, etc.)
- Updated Fish function filename to match the new name

## Why?
The previous function name `pw` was too similar to the common Unix command `pwd`, which could cause confusion. `jump` is more descriptive and clearly indicates the function's purpose of jumping between workspaces.

---
Generated with Claude's assistance