### PR TITLE
feat: add panama root command to find project root directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ panama list --max-depth 2
 panama init
 ```
 
+### Find monorepo root
+
+```bash
+# Print root directory containing panama config
+panama root
+
+# Output as cd command
+panama root -f cd
+```
+
 ## Configuration
 
 Panama looks for configuration files in the following order:
@@ -139,6 +149,19 @@ jump() {
     cd "$dir"
   fi
 }
+
+# Navigate to monorepo root
+# Quickly jump to the root directory containing the panama config or .git
+cdroot() {
+  local dir
+  dir=$(panama root 2>/dev/null)
+  if [[ -n "$dir" ]]; then
+    cd "$dir"
+  else
+    echo "No root workspace found in parent directories" >&2
+    return 1
+  fi
+}
 ```
 
 ### Fish
@@ -151,6 +174,22 @@ function jump
   set -l dir (panama select $argv)
   if test -n "$dir"
     cd $dir
+  end
+end
+```
+
+Add to your `~/.config/fish/functions/cdroot.fish`:
+
+```fish
+# Navigate to monorepo root
+# Quickly jump to the root directory containing the panama config or .git
+function cdroot
+  set -l dir (panama root 2>/dev/null)
+  if test -n "$dir"
+    cd $dir
+  else
+    echo "No root workspace found in parent directories" >&2
+    return 1
   end
 end
 ```

--- a/cmd/panama/main.go
+++ b/cmd/panama/main.go
@@ -35,6 +35,7 @@ It automatically detects Git repositories and project directories with package f
 		newSelectCommand(),
 		newListCommand(),
 		newInitCommand(),
+		newRootCommand(),
 		newVersionCommand(),
 	)
 

--- a/cmd/panama/root.go
+++ b/cmd/panama/root.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/yuya-takeyama/panama/internal/output"
+)
+
+type rootOptions struct {
+	format string
+	config string
+}
+
+func newRootCommand() *cobra.Command {
+	opts := &rootOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "root",
+		Short: "Print the root directory containing panama config or .git",
+		Long: `Print the path to the first parent directory containing a panama configuration file or .git directory.
+This is useful for navigating to the monorepo or project root directory.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRoot(opts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.format, "format", "f", "path", "Output format (path|cd|json)")
+	flags.StringVar(&opts.config, "config", "", "Path to configuration file")
+
+	return cmd
+}
+
+func runRoot(opts *rootOptions) error {
+	// Parse output format
+	format, err := output.ParseFormat(opts.format)
+	if err != nil {
+		return err
+	}
+
+	// If config path is provided, use its directory
+	if opts.config != "" {
+		configDir := filepath.Dir(opts.config)
+		absDir, err := filepath.Abs(configDir)
+		if err != nil {
+			return fmt.Errorf("failed to resolve config directory: %w", err)
+		}
+		return output.Print(absDir, format)
+	}
+
+	// Search for config file or .git directory upward from current directory
+	currentDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	dir := currentDir
+	for {
+		// First, check for panama config files
+		for _, name := range []string{".panama.yaml", ".panama.yml"} {
+			path := filepath.Join(dir, name)
+			if _, err := os.Stat(path); err == nil {
+				// Found config file, return this directory
+				return output.Print(dir, format)
+			}
+		}
+
+		// Also check for .git directory as fallback
+		gitPath := filepath.Join(dir, ".git")
+		if stat, err := os.Stat(gitPath); err == nil && stat.IsDir() {
+			// Found .git directory, return this directory
+			return output.Print(dir, format)
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+
+	// No config or .git found
+	return fmt.Errorf("no root workspace found in any parent directory")
+}

--- a/cmd/panama/root_test.go
+++ b/cmd/panama/root_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRootCommand(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(t *testing.T) string // Returns temp dir
+		opts      *rootOptions
+		wantErr   bool
+		wantInOut bool // Check if output contains the temp dir path
+	}{
+		{
+			name: "finds config in current directory",
+			setup: func(t *testing.T) string {
+				tmpDir := t.TempDir()
+				configPath := filepath.Join(tmpDir, ".panama.yaml")
+				if err := os.WriteFile(configPath, []byte("max_depth: 5\n"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Chdir(tmpDir); err != nil {
+					t.Fatal(err)
+				}
+				return tmpDir
+			},
+			opts:      &rootOptions{format: "path"},
+			wantErr:   false,
+			wantInOut: true,
+		},
+		{
+			name: "finds config in parent directory",
+			setup: func(t *testing.T) string {
+				tmpDir := t.TempDir()
+				configPath := filepath.Join(tmpDir, ".panama.yaml")
+				if err := os.WriteFile(configPath, []byte("max_depth: 5\n"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				subDir := filepath.Join(tmpDir, "subdir")
+				if err := os.MkdirAll(subDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Chdir(subDir); err != nil {
+					t.Fatal(err)
+				}
+				return tmpDir
+			},
+			opts:      &rootOptions{format: "path"},
+			wantErr:   false,
+			wantInOut: true,
+		},
+		{
+			name: "finds .git directory when no config",
+			setup: func(t *testing.T) string {
+				tmpDir := t.TempDir()
+				gitDir := filepath.Join(tmpDir, ".git")
+				if err := os.MkdirAll(gitDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				subDir := filepath.Join(tmpDir, "subdir")
+				if err := os.MkdirAll(subDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Chdir(subDir); err != nil {
+					t.Fatal(err)
+				}
+				return tmpDir
+			},
+			opts:      &rootOptions{format: "path"},
+			wantErr:   false,
+			wantInOut: true,
+		},
+		{
+			name: "no config or git found",
+			setup: func(t *testing.T) string {
+				tmpDir := t.TempDir()
+				if err := os.Chdir(tmpDir); err != nil {
+					t.Fatal(err)
+				}
+				return tmpDir
+			},
+			opts:    &rootOptions{format: "path"},
+			wantErr: true,
+		},
+		{
+			name: "uses provided config path",
+			setup: func(t *testing.T) string {
+				tmpDir := t.TempDir()
+				configDir := filepath.Join(tmpDir, "config")
+				if err := os.MkdirAll(configDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				configPath := filepath.Join(configDir, "custom.yaml")
+				if err := os.WriteFile(configPath, []byte("max_depth: 5\n"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				return configDir
+			},
+			opts: &rootOptions{
+				format: "path",
+				config: filepath.Join(t.TempDir(), "config", "custom.yaml"),
+			},
+			wantErr:   false,
+			wantInOut: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save current directory to restore later
+			originalDir, err := os.Getwd()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.Chdir(originalDir)
+
+			// Setup test environment
+			tmpDir := tt.setup(t)
+
+			// Update config path if it's relative to temp dir
+			if tt.opts.config != "" && !filepath.IsAbs(tt.opts.config) {
+				tt.opts.config = filepath.Join(tmpDir, "config", "custom.yaml")
+			}
+
+			// Capture stdout
+			oldStdout := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+
+			// Run the command
+			err = runRoot(tt.opts)
+
+			// Restore stdout
+			w.Close()
+			os.Stdout = oldStdout
+
+			// Check error
+			if (err != nil) != tt.wantErr {
+				t.Errorf("runRoot() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			// Check output contains expected path
+			if tt.wantInOut && err == nil {
+				buf := make([]byte, 1024)
+				n, _ := r.Read(buf)
+				output := string(buf[:n])
+				if output == "" {
+					t.Errorf("expected output to contain path, got empty string")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add new `panama root` command that finds and prints the root directory containing panama config or .git
- Support for `--format` option (path|cd|json) similar to the select command
- Falls back to .git directory when no panama configuration is found

## Motivation

This command simplifies navigation to the monorepo root directory from any subdirectory. Users can quickly jump back to the project root without manually navigating through parent directories.

## Changes

- Add `cmd/panama/root.go` with the new root command implementation
- Add comprehensive tests in `cmd/panama/root_test.go`
- Update README with `cdroot` shell function examples for Bash/Zsh/Fish
- Register the new command in `cmd/panama/main.go`

## Test plan

- [x] Unit tests added for all scenarios (config in current dir, parent dir, .git fallback, no root found)
- [x] Manual testing with `panama root` command
- [x] Manual testing with different output formats (`-f cd`, `-f json`)
- [x] Shell function examples tested in README

---
Generated with Claude's assistance